### PR TITLE
Add moment to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "hubot": "2.x",
     "matchdep": "~0.3.0",
     "mocha": "^2.1.0",
+    "moment": "^2.13.0",
     "sinon": "^1.13.0",
     "sinon-chai": "^2.7.0"
   },


### PR DESCRIPTION
`moment` is required, but was previously not included in `package.json`.
