### PR TITLE
Document the Streaming feature, ensure only sends on change

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,49 @@ Set the entity state to the given value.
 <hubot> @alice Setting Bob's iPhone to home
 <hubot> @alice Bob's iPhone set to home
 ```
+
+## Streaming Capabilities
+
+In addition to directly interacting with Home Assistant, this package will allow you to stream entity status changes (e.g. turn a light on, home temperature rises, etc.) into a room/channel/user of your choice.
+
+1. Set `HUBOT_HOME_ASSISTANT_MONITOR_EVENTS` to any value to enable streaming.
+2. Set `HUBOT_HOME_ASSISTANT_EVENTS_DESTINATION` to where you want the messages to be seen. By default, they will go to a channel/room called `#home-assistant`.
+3. Restart your Hubot
+
+### Option 1 - Monitor Everything
+
+Note that Home Assistant will send a lot of change events throughout the day if you have several components configured. For example, if you have a thermostat configured, it will send an event for every detected temperature change.
+
+1. Set `HUBOT_HOME_ASSISTANT_MONITOR_ALL_ENTITIES` to any value.
+2. Restart your Hubot
+
+### Option 2 - Monitor Specific Devices
+
+1. Ensure that `HUBOT_HOME_ASSISTANT_MONITOR_ALL_ENTITIES` is not set in the configuration.
+2. Update your Home Assistant configuration under the `customize`, `customize_domain` or `customize_blob` key to include the `hubot_monitor: true` attribute. [See documentation](https://www.home-assistant.io/docs/configuration/customizing-devices/) for more details.
+3. Restart your Hubot
+
+**Examples:**
+
+```yaml
+homeassistant:
+
+  #...
+
+  # Set a specific device to monitor
+  customize:
+    climate.my_ecobee3:
+      hubot_monitor: true
+
+  # Monitor all devices in a particular domain
+  customize_domain:
+    alarm_control_panel:
+      hubot_monitor: true
+    light:
+      hubot_monitor: true
+
+  # Monitor devices matching a pattern
+  customize_blob:
+    "device_tracker.*_iphone":
+      hubot_monitor: true
+```

--- a/src/home-assistant-streaming.coffee
+++ b/src/home-assistant-streaming.coffee
@@ -148,6 +148,10 @@ module.exports = (robot) ->
     @es = new EventSource("#{process.env.HUBOT_HOME_ASSISTANT_HOST}/api/stream", {headers: {'x-ha-access': process.env.HUBOT_HOME_ASSISTANT_API_PASSWORD}})
     @es.addEventListener 'message', (msg) ->
       if msg.data != "ping"
-        msgData = JSON.parse(msg.data)
-        if msgData.event_type == "state_changed"
-          sendEvent msgData
+        try
+          msgData = JSON.parse(msg.data)
+          if msgData.event_type == "state_changed" and msgData.data.old_state.state != msgData.data.new_state.state
+            robot.logger.debug msgData
+            sendEvent msgData
+        catch e
+          robot.logger.error e

--- a/src/home-assistant.coffee
+++ b/src/home-assistant.coffee
@@ -33,7 +33,7 @@ module.exports = (robot) ->
   hassUrl = new URL(process.env.HUBOT_HOME_ASSISTANT_HOST)
   hass = new HomeAssistant({
     host: "#{hassUrl.protocol}//#{hassUrl.hostname}",
-    port: hassUrl.port,
+    port: if !hassUrl.port then (if hassUrl.protocol == 'https:' then '443' else '80') else hassUrl.port,
     password: process.env.HUBOT_HOME_ASSISTANT_API_PASSWORD,
     ignoreCert: process.env.HUBOT_HOME_ASSISTANT_IGNORE_CERT || false
   })

--- a/test/home-assistant_stream_test.coffee
+++ b/test/home-assistant_stream_test.coffee
@@ -18,7 +18,7 @@ mockDateNow = () ->
 describe 'home-assistant streaming', ->
   beforeEach ->
     process.env.HUBOT_LOG_LEVEL='error'
-    process.env.HUBOT_HOME_ASSISTANT_HOST='http://hassio.local'
+    process.env.HUBOT_HOME_ASSISTANT_HOST='http://hassio.local:8123'
     process.env.HUBOT_HOME_ASSISTANT_API_PASSWORD='foobar'
     process.env.HUBOT_HOME_ASSISTANT_MONITOR_EVENTS='true'
     process.env.HUBOT_HOME_ASSISTANT_EVENTS_DESTINATION='room1'

--- a/test/home-assistant_test.coffee
+++ b/test/home-assistant_test.coffee
@@ -17,7 +17,7 @@ mockDateNow = () ->
 describe 'home-assistant', ->
   beforeEach ->
     process.env.HUBOT_LOG_LEVEL='error'
-    process.env.HUBOT_HOME_ASSISTANT_HOST='http://hassio.local'
+    process.env.HUBOT_HOME_ASSISTANT_HOST='http://hassio.local:8123'
     process.env.HUBOT_HOME_ASSISTANT_API_PASSWORD='foobar'
     Date.now = mockDateNow
     nock.disableNetConnect()


### PR DESCRIPTION
While I was not able to get tests around this feature, I did dig into it to make sure it was still working as expected. Fixed a minor bug and documented how to use it.

- Updates the README to specify how to use the streaming feature effectively
- Fixes an issue where a `status_change` would have the same `status` attribute, resulting in a redundant message
- Fixes a separate issue where using port `80` (non-SSL) or `443` (SSL) would fallback to 8123 because of the new underlying library's default and the behavior of the `url` module.