### PR TITLE
Namespace the commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,30 +30,30 @@ Then add **hubot-home-assistant** to your `external-scripts.json`:
 
 ## Commands:
 
-### `hubot state of <friendly name of entity>`
+### Get the state of an entity
 
-Returns the current state of the entity
+Returns the current state of the entity.
 
 ```
-<alice> hubot state of Living Room Downlights
+<alice> hubot hass state of Living Room Downlights
 <hubot> @alice Living Room Downlights is off (since 2 hours ago)
 ```
 
-### `hubot turn <friendly name of entity> <on|off>`
+### Toggle an entity on or off
 
 Turn the entity on/off.
 
 ```
-<alice> hubot turn Living Room Downlights on
+<alice> hubot hass turn Living Room Downlights on
 <hubot> @alice Living Room Downlights turned on
 ```
 
-### `hubot set <friendly name of entity> to <new state>`
+### Set an entity to a desired state
 
 Set the entity state to the given value.
 
 ```
-<alice> hubot set Bob's iPhone to home
+<alice> hubot hass set Bob's iPhone to home
 <hubot> @alice Setting Bob's iPhone to home
 <hubot> @alice Bob's iPhone set to home
 ```

--- a/src/home-assistant.coffee
+++ b/src/home-assistant.coffee
@@ -9,9 +9,9 @@
 #   HUBOT_HOME_ASSISTANT_EVENTS_DESTINATION - which room/channel/chat to send events to
 #
 # Commands:
-#   hubot state of <friendly name of entity> - returns the current state of the entity
-#   hubot turn <friendly name of entity> <on|off> - turn the entity on/off
-#   hubot set <friendly name of entity> to <new state> - set the entity state to the given value
+#   hubot hass state of <friendly name of entity> - returns the current state of the entity
+#   hubot hass turn <friendly name of entity> <on|off> - turn the entity on/off
+#   hubot hass set <friendly name of entity> to <new state> - set the entity state to the given value
 #
 # Author:
 #   Robbie Trencheny <me@robbiet.us>
@@ -89,7 +89,7 @@ module.exports = (robot) ->
 
   ##
   # Get the current state of a device
-  robot.respond /state of (.*)/i, (res) ->
+  robot.respond /(?:hass|ha) state of (.*)/i, (res) ->
     getDeviceByFriendlyName(res.match[1])
     .then (device) ->
       robot.logger.debug 'device', device
@@ -101,7 +101,7 @@ module.exports = (robot) ->
 
   ##
   # Turn a device on/off
-  robot.respond /turn (.*) (on|off)/i, (res) ->
+  robot.respond /(?:hass|ha) turn (.*) (on|off)/i, (res) ->
     friendlyName = res.match[1]
     state = res.match[2]
     setPower(friendlyName, state)
@@ -113,7 +113,7 @@ module.exports = (robot) ->
 
   ##
   # Set a device to a particular state
-  robot.respond /set (.*) to (.*)/i, (res) ->
+  robot.respond /(?:hass|ha) set (.*) to (.*)/i, (res) ->
     friendlyName = res.match[1]
     state = res.match[2]
     res.reply "Setting #{friendlyName} to #{state}"

--- a/test/home-assistant_stream_test.coffee
+++ b/test/home-assistant_stream_test.coffee
@@ -6,7 +6,6 @@ fs = require 'fs'
 expect = chai.expect
 
 helper = new Helper [
-  '../src/home-assistant.coffee',
   '../src/home-assistant-streaming.coffee'
 ]
 

--- a/test/home-assistant_test.coffee
+++ b/test/home-assistant_test.coffee
@@ -5,8 +5,7 @@ nock = require 'nock'
 expect = chai.expect
 
 helper = new Helper [
-  '../src/home-assistant.coffee',
-  '../src/home-assistant-streaming.coffee'
+  '../src/home-assistant.coffee'
 ]
 
 # Alter time as test runs
@@ -37,11 +36,11 @@ describe 'home-assistant', ->
       .replyWithFile(200, __dirname + '/fixtures/states.json')
 
     selfRoom = @room
-    selfRoom.user.say('alice', '@hubot state of Den')
+    selfRoom.user.say('alice', '@hubot hass state of Den')
     setTimeout(() ->
       try
         expect(selfRoom.messages).to.eql [
-          ['alice', '@hubot state of Den']
+          ['alice', '@hubot hass state of Den']
           ['hubot', '@alice Den is idle (since 8 hours ago)']
         ]
         done()
@@ -56,11 +55,11 @@ describe 'home-assistant', ->
       .replyWithFile(200, __dirname + '/fixtures/states.json')
 
     selfRoom = @room
-    selfRoom.user.say('alice', '@hubot state of Not Found Device')
+    selfRoom.user.say('alice', '@hubot hass state of Not Found Device')
     setTimeout(() ->
       try
         expect(selfRoom.messages).to.eql [
-          ['alice', '@hubot state of Not Found Device']
+          ['alice', '@hubot hass state of Not Found Device']
           ['hubot', 'No device found with that name!']
         ]
         done()
@@ -78,11 +77,11 @@ describe 'home-assistant', ->
       .replyWithFile(200, __dirname + '/fixtures/device-turn_on.json')
 
     selfRoom = @room
-    selfRoom.user.say('alice', '@hubot turn Living Room Downlights on')
+    selfRoom.user.say('alice', '@hubot hass turn Living Room Downlights on')
     setTimeout(() ->
       try
         expect(selfRoom.messages).to.eql [
-          ['alice', '@hubot turn Living Room Downlights on']
+          ['alice', '@hubot hass turn Living Room Downlights on']
           ['hubot', '@alice Living Room Downlights turned on']
         ]
         done()
@@ -97,11 +96,11 @@ describe 'home-assistant', ->
       .replyWithFile(200, __dirname + '/fixtures/states.json')
 
     selfRoom = @room
-    selfRoom.user.say('alice', '@hubot turn Does Not Exist on')
+    selfRoom.user.say('alice', '@hubot hass turn Does Not Exist on')
     setTimeout(() ->
       try
         expect(selfRoom.messages).to.eql [
-          ['alice', '@hubot turn Does Not Exist on']
+          ['alice', '@hubot hass turn Does Not Exist on']
           ['hubot', 'No device found with that name!']
         ]
         done()
@@ -119,11 +118,11 @@ describe 'home-assistant', ->
       .replyWithFile(200, __dirname + '/fixtures/device-tracker-set_home.json')
 
     selfRoom = @room
-    selfRoom.user.say('alice', '@hubot set Stephen\'s iPhone 6 to home')
+    selfRoom.user.say('alice', '@hubot hass set Stephen\'s iPhone 6 to home')
     setTimeout(() ->
       try
         expect(selfRoom.messages).to.eql [
-          ['alice', '@hubot set Stephen\'s iPhone 6 to home']
+          ['alice', '@hubot hass set Stephen\'s iPhone 6 to home']
           ['hubot', '@alice Setting Stephen\'s iPhone 6 to home']
           ['hubot', '@alice Stephen\'s iPhone 6 set to home']
         ]
@@ -139,11 +138,11 @@ describe 'home-assistant', ->
       .replyWithFile(200, __dirname + '/fixtures/states.json')
 
     selfRoom = @room
-    selfRoom.user.say('alice', '@hubot set Does Not Exist to home')
+    selfRoom.user.say('alice', '@hubot hass set Does Not Exist to home')
     setTimeout(() ->
       try
         expect(selfRoom.messages).to.eql [
-          ['alice', '@hubot set Does Not Exist to home']
+          ['alice', '@hubot hass set Does Not Exist to home']
           ['hubot', '@alice Setting Does Not Exist to home']
           ['hubot', 'No device found with that name!']
         ]


### PR DESCRIPTION
Allow a user to prefix the commands with `hass` or `ha` rather than use the shorter form. Helps avoid collisions with other Hubot scripts that similarly uses "set", "get" or "turn" as a trigger word.

For users that want to preserve the existing behavior, they could continue to use `v0.0.1` or use [`hubot-alias`](https://github.com/dtaniwaki/hubot-alias).