### PR TITLE
Switch Gruntfile.js configuration into .release-it.json

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,6 @@
+{
+  "pkgFiles": ["package.json", "package-lock.json"],
+  "github": {
+    "release": true
+  }
+}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,13 +12,6 @@ module.exports = function (grunt) {
         src: ['test/**/*.coffee']
       }
     },
-    release: {
-      options: {
-        tagName: 'v<%= version %>',
-        commitMessage: 'Prepared to release <%= version %>.',
-        additionalFiles: ['package-lock.json']
-      }
-    },
     watch: {
       files: ['Gruntfile.js', 'src/**/*.coffee', 'test/**/*.coffee'],
       tasks: ['test']


### PR DESCRIPTION
Essential change is that the version number in `package-lock.json` file is kept in sync with `package.json`.